### PR TITLE
Send login instructions by mail after installation (#15)

### DIFF
--- a/conf/msg_install
+++ b/conf/msg_install
@@ -8,4 +8,5 @@ The secret is: __API_SECRET__
 
 Please note that if you did NOT install the application in public mode, you should go to the Yunohost login portal first to authenticate yourself in order to access to the application.
 
-If you are facing any problem or want to improve this app, please open a new issue here: https://github.com/YunoHost-Apps/invoiceninja5_ynh/issues
+If you are facing any problems, head to the forums: https://forum.yunohost.org/
+If you want to improve this app, please open a new issue here: https://github.com/YunoHost-Apps/invoiceninja5_ynh/issues

--- a/conf/msg_install
+++ b/conf/msg_install
@@ -1,0 +1,11 @@
+__APP__ was successfully installed :)
+
+Please open your __APP__ domain: https://__DOMAIN____PATH_URL__
+
+The username is: __EMAIL__
+The password is the administrator one you filled during the installation
+The secret is: __API_SECRET__
+
+Please note that if you did NOT install the application in public mode, you should go to the Yunohost login portal first to authenticate yourself in order to access to the application.
+
+If you are facing any problem or want to improve this app, please open a new issue here: https://github.com/YunoHost-Apps/invoiceninja5_ynh/issues

--- a/scripts/install
+++ b/scripts/install
@@ -8,6 +8,7 @@
 
 source _common.sh
 source /usr/share/yunohost/helpers
+source ynh_send_readme_to_admin__2
 
 #=================================================
 # MANAGE SCRIPT FAILURE
@@ -181,6 +182,13 @@ fi
 ynh_script_progression --message="Reloading NGINX web server..."
 
 ynh_systemd_action --service_name=nginx --action=reload
+
+#=================================================
+# SEND A README FOR THE ADMIN
+#=================================================
+ynh_script_progression --message="Sending a readme for the admin..."
+
+ynh_send_readme_to_admin --app_message="../conf/msg_install" --recipients=$email --type='install'
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -6,9 +6,9 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
+source ynh_send_readme_to_admin__2
 source _common.sh
 source /usr/share/yunohost/helpers
-source ynh_send_readme_to_admin__2
 
 #=================================================
 # MANAGE SCRIPT FAILURE

--- a/scripts/ynh_send_readme_to_admin__2
+++ b/scripts/ynh_send_readme_to_admin__2
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Send an email to inform the administrator
+#
+# usage: ynh_send_readme_to_admin --app_message=app_message [--recipients=recipients] [--type=type]
+# | arg: -m --app_message= - The file with the content to send to the administrator.
+# | arg: -r, --recipients= - The recipients of this email. Use spaces to separate multiples recipients. - default: root
+#	example: "root admin@domain"
+#	If you give the name of a YunoHost user, ynh_send_readme_to_admin will find its email adress for you
+#	example: "root admin@domain user1 user2"
+# | arg: -t, --type= - Type of mail, could be 'backup', 'change_url', 'install', 'remove', 'restore', 'upgrade'
+#
+# Requires YunoHost version 4.1.0 or higher.
+ynh_send_readme_to_admin() {
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [m]=app_message= [r]=recipients= [t]=type= )
+	local app_message
+	local recipients
+	local type
+	# Manage arguments with getopts
+
+	ynh_handle_getopts_args "$@"
+	app_message="${app_message:-}"
+	recipients="${recipients:-root}"
+	type="${type:-install}"
+
+	# Get the value of admin_mail_html
+	admin_mail_html=$(ynh_app_setting_get $app admin_mail_html)
+	admin_mail_html="${admin_mail_html:-0}"
+
+	# Retrieve the email of users
+	find_mails () {
+		local list_mails="$1"
+		local mail
+		local recipients=" "
+		# Read each mail in argument
+		for mail in $list_mails
+		do
+			# Keep root or a real email address as it is
+			if [ "$mail" = "root" ] || echo "$mail" | grep --quiet "@"
+			then
+				recipients="$recipients $mail"
+			else
+				# But replace an user name without a domain after by its email
+				if mail=$(ynh_user_get_info "$mail" "mail" 2> /dev/null)
+				then
+					recipients="$recipients $mail"
+				fi
+			fi
+		done
+		echo "$recipients"
+	}
+	recipients=$(find_mails "$recipients")
+
+	# Subject base
+	local mail_subject="☁️🆈🅽🅷☁️: \`$app\`"
+
+	# Adapt the subject according to the type of mail required.
+	if [ "$type" = "backup" ]; then
+		mail_subject="$mail_subject has just been backup."
+	elif [ "$type" = "change_url" ]; then
+		mail_subject="$mail_subject has just been moved to a new URL!"
+	elif [ "$type" = "remove" ]; then
+		mail_subject="$mail_subject has just been removed!"
+	elif [ "$type" = "restore" ]; then
+		mail_subject="$mail_subject has just been restored!"
+	elif [ "$type" = "upgrade" ]; then
+		mail_subject="$mail_subject has just been upgraded!"
+	else	# install
+		mail_subject="$mail_subject has just been installed!"
+	fi
+
+	ynh_add_config --template="$app_message" --destination="../conf/msg__to_send"
+
+	ynh_delete_file_checksum --file="../conf/msg__to_send"
+
+	local mail_message="This is an automated message from your beloved YunoHost server.
+
+Specific information for the application $app.
+
+$(cat "../conf/msg__to_send")"
+
+	# Store the message into a file for further modifications.
+	echo "$mail_message" > mail_to_send
+
+	# If a html email is required. Apply html tags to the message.
+ 	if [ "$admin_mail_html" -eq 1 ]
+ 	then
+		# Insert 'br' tags at each ending of lines.
+		ynh_replace_string "$" "<br>" mail_to_send
+
+		# Insert starting HTML tags
+		sed --in-place '1s@^@<!DOCTYPE html>\n<html>\n<head></head>\n<body>\n@' mail_to_send
+
+		# Keep tabulations
+		ynh_replace_string "  " "\&#160;\&#160;" mail_to_send
+		ynh_replace_string "\t" "\&#160;\&#160;" mail_to_send
+
+		# Insert url links tags
+		ynh_replace_string "__URL_TAG1__\(.*\)__URL_TAG2__\(.*\)__URL_TAG3__" "<a href=\"\2\">\1</a>" mail_to_send
+
+		# Insert finishing HTML tags
+		echo -e "\n</body>\n</html>" >> mail_to_send
+
+	# Otherwise, remove tags to keep a plain text.
+	else
+		# Remove URL tags
+		ynh_replace_string "__URL_TAG[1,3]__" "" mail_to_send
+		ynh_replace_string "__URL_TAG2__" ": " mail_to_send
+	fi
+
+	# Define binary to use for mail command
+	if [ -e /usr/bin/bsd-mailx ]
+	then
+		local mail_bin=/usr/bin/bsd-mailx
+	else
+		local mail_bin=/usr/bin/mail.mailutils
+	fi
+
+	if [ "$admin_mail_html" -eq 1 ]
+	then
+		content_type="text/html"
+	else
+		content_type="text/plain"
+	fi
+
+	# Send the email to the recipients
+	cat mail_to_send | $mail_bin -a "Content-Type: $content_type; charset=UTF-8" -s "$mail_subject" "$recipients"
+}

--- a/scripts/ynh_send_readme_to_admin__2
+++ b/scripts/ynh_send_readme_to_admin__2
@@ -53,7 +53,7 @@ ynh_send_readme_to_admin() {
 	recipients=$(find_mails "$recipients")
 
 	# Subject base
-	local mail_subject="☁️🆈🅽🅷☁️: \`$app\`"
+	local mail_subject="\`$app\`"
 
 	# Adapt the subject according to the type of mail required.
 	if [ "$type" = "backup" ]; then


### PR DESCRIPTION
## Problem

- See #15 
  - Missing information about secret key for loging
  - Missing instruction on how to access app if not in public mode

## Solution

- Send email with login instructions (secret key included) and instruction on how to access app if not in public mode

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
