### PR TITLE
install snappdf, since its not included by default anymore

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -150,6 +150,10 @@ pushd "$final_path"
 	php$phpversion artisan optimize --no-interaction --verbose
 	php$phpversion artisan view:clear
 	php$phpversion artisan cache:clear
+
+	# install snappdf, since it isn't included by default anymore since
+	# 5.5.12: https://invoiceninja.github.io/docs/self-host-troubleshooting/#pdf-conversion-issues
+	php$phpversion vendor/bin/snappdf download
 popd
 
 chmod 750 "$final_path"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -152,6 +152,10 @@ pushd "$final_path"
 	# clear cached stuff under /app/data/storage/framework (https://github.com/laravel/framework/issues/17377)
 	php$phpversion artisan view:clear
 	php$phpversion artisan cache:clear
+
+	# install snappdf, since it isn't included by default anymore since
+	# 5.5.12: https://invoiceninja.github.io/docs/self-host-troubleshooting/#pdf-conversion-issues
+	php$phpversion vendor/bin/snappdf download
 popd
 
 chmod 750 "$final_path"


### PR DESCRIPTION
## Problem

install snappdf, since it isn't included by default anymore since 5.5.12: https://invoiceninja.github.io/docs/self-host-troubleshooting/#pdf-conversion-issues

## Solution

- install it 

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
