### PR TITLE
Fix autoupdate

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -62,7 +62,7 @@ ram.runtime = "50M"
         sha256 = "bb470136407d4cede9739e9401d792d0f098b51ed21661e7eb6e14aebdf87114"
         in_subdir = false
         autoupdate.strategy = "latest_github_release"
-        autoupdate.asset = "invoiceninja.zip"
+        autoupdate.asset = "invoiceninja.tar"
 
     [resources.system_user]
 


### PR DESCRIPTION
## Problem

Autoupdate fails. See https://paste.yunohost.org/raw/obuximumef

```
Traceback (most recent call last):
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 637, in run_autoupdate_for_multiprocessing
    result = AppAutoUpdater(app).run(edit=edit, commit=commit, pr=pr)
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 233, in run
    update = self.get_source_update(source, infos)
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 387, in get_source_update
    result = self.get_latest_version_and_asset(strategy, asset, autoupdate)
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 507, in get_latest_version_and_asset
    raise RuntimeError(
RuntimeError: No assets matching regex 'invoiceninja.zip' in ['invoiceninja.tar'].
Full release details on https://github.com/invoiceninja/invoiceninja/releases/tag/v5.10.3.
```

## Solution

Apparently since v5.9.3 there is no zip file asset in the releases anymore. I inquired about it [here](https://github.com/invoiceninja/invoiceninja/discussions/9708#discussioncomment-9898695) and the devs dropped it in favor of a .tar file with the same contents. 

So, I updated the autoupdate asset from .zip to .tar. I believe as the structure and contents are identical, the installation procedure should stay the same.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
