### PR TITLE
Fix .env permissions (marked in health check)

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -58,7 +58,7 @@ ynh_script_progression --message="Modifying a config file..." --weight=1
 
 ynh_add_config --template="default.env" --destination="$install_dir/.env"
 
-chmod 400 "$install_dir/.env"
+chmod 600 "$install_dir/.env"
 chown $app:$app "$install_dir/.env"
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -69,7 +69,7 @@ then
 
        ynh_add_config --template="default.env" --destination="$install_dir/.env"
 
-       chmod 400 "$install_dir/.env"
+       chmod 600 "$install_dir/.env"
        chown $app:$app "$install_dir/.env"
 fi
 


### PR DESCRIPTION
## Problem

Apparently, due to InvoiceNinja's health check the `.env` file should be writeable. See
![image](https://github.com/YunoHost-Apps/invoiceninja5_ynh/assets/19874562/a80339a9-d419-4cb6-835d-5032e952ca93)

Was also mentioned in this issue: https://github.com/YunoHost-Apps/invoiceninja5_ynh/issues/278

Also, I think this is why the config panel isn't working what you mentioned here https://forum.yunohost.org/t/config-panel-seems-to-be-broken-for-me/28980 . Can you try again to make config panel work with the adopted permissions? I think it would be great to have a config panel for the Invoice Ninja YNH app. Thanks for your great work @rndmh3ro :rocket: 

## Solution

Adopted permissions with `chmod 600` (instead of `chmod 400`).

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
