### PR TITLE
Update PHP version to 8.4

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -80,7 +80,7 @@ ram.runtime = "50M"
     api.show_tile = false
 
     [resources.apt]
-    packages = "mariadb-server, php8.3-bcmath, php8.3-gmp, php8.3-fileinfo, php8.3-gd, php8.3-mbstring, php8.3-pdo, php8.3-xml, php8.3-curl, php8.3-zip, php8.3-mysql, libnss3-dev, libatk1.0-0, libatk-bridge2.0-0, libxcomposite1, libxrandr2, libasound2, libcups2, libdrm2, libxkbcommon0, libxdamage1, libxfixes3, libgbm1, libpango-1.0-0, libcairo2, chromium"
+    packages = "mariadb-server, php8.4-bcmath, php8.4-gmp, php8.4-fileinfo, php8.4-gd, php8.4-mbstring, php8.4-pdo, php8.4-xml, php8.4-curl, php8.4-zip, php8.4-mysql, libnss3-dev, libatk1.0-0, libatk-bridge2.0-0, libxcomposite1, libxrandr2, libasound2, libcups2, libdrm2, libxkbcommon0, libxdamage1, libxfixes3, libgbm1, libpango-1.0-0, libcairo2, chromium"
 
     [resources.database]
     type = "mysql"


### PR DESCRIPTION
## Problem

Active support of PHP 8.3 ended end of last year, see https://endoflife.date/php

## Solution

Update PHP version to PHP 8.4. which seems to be supported for InvoiceNinja, see https://forum.invoiceninja.com/t/php-8-4-support/17532/5

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
