### PR TITLE
fix: disable SSO auth header injection to prevent login loop

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -72,6 +72,7 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
+    main.auth_header = false
     api.url = "/api"
     api.allowed = "visitors"
     api.auth_header = false


### PR DESCRIPTION
## Problem

Users experience a **silent login loop** when accessing the Invoice Ninja web UI while logged into YunoHost SSO: the app loads briefly, then redirects back to the login page with no error message.

## Root cause

SSOwat injects an `Authorization: Basic <base64(yunohost_user:yunohost_password)>` header into every proxied request when `auth_header` is not explicitly `false`. Invoice Ninja receives this header and attempts to authenticate the YunoHost user against its own database. That user does not exist in Invoice Ninja, so authentication fails silently and the app redirects to its login page.

## Fix

Add `main.auth_header = false` to `[resources.permissions]` in `manifest.toml`.

Note that the `api` permission already correctly sets `auth_header = false` — this is what allows the mobile app and API tokens to work. The same logic applies to the main web UI: Invoice Ninja handles its own authentication and should not receive injected YunoHost credentials.

## Consistency

The app already declares:
```toml
ldap = false
sso = false
```

Setting `main.auth_header = false` is consistent with these declarations and with the existing `api.auth_header = false`.

## Testing

Verified on a live YunoHost 12 install (Debian 13):
- Before fix: silent login loop when YunoHost session is active; mobile app (using API tokens) worked correctly
- After fix (manual `auth_header = false` in ssowat conf): web UI login works correctly